### PR TITLE
Fix import section in service_instance_bind documentation

### DIFF
--- a/docs/resources/service_instance_bind.md
+++ b/docs/resources/service_instance_bind.md
@@ -40,5 +40,5 @@ resource "tsuru_service_instance_bind" "instance_bind" {
 Import is supported using the following syntax:
 
 ```shell
-terraform import tsuru.service_instance_bind.my_bind "SERVICE::INSTANCE::APP"
+terraform import tsuru_service_instance_bind.my_bind "SERVICE::INSTANCE::APP"
 ```


### PR DESCRIPTION
This PR fixes the `terraform import` sintax in `service_instance_bind` docs.