### PR TITLE
fix VolumeBindRead

### DIFF
--- a/internal/provider/resource_tsuru_volume_bind.go
+++ b/internal/provider/resource_tsuru_volume_bind.go
@@ -137,14 +137,13 @@ func resourceTsuruVolumeBindRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	for _, bind := range volume.Binds {
-		if bind.Id.App != app && bind.Id.Mountpoint != mountPath {
-			continue
+		if bind.Id.App == app && bind.Id.Mountpoint == mountPath {
+			d.Set("volume", name)
+			d.Set("app", app)
+			d.Set("mount_point", bind.Id.Mountpoint)
+			d.Set("read_only", bind.Readonly)
+			return nil
 		}
-		d.Set("volume", name)
-		d.Set("app", app)
-		d.Set("mount_point", bind.Id.Mountpoint)
-		d.Set("read_only", bind.Readonly)
-		return nil
 	}
 
 	d.SetId("")


### PR DESCRIPTION
`if bind.Id.App != app && bind.Id.Mountpoint != mountPath { continue }` means it will continue only if both are different.
It should continue if either one is different (`&&` should be `||`)

In order to be easier to read, I converted it to a positive match instead


fixes #36 

