### PR TITLE
feat: add tsuru_service resource for managing service definitions

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=tsuru
 NAME=tsuru
 BINARY=terraform-provider-${NAME}
-VERSION=2.15.8
+VERSION=2.17.2
 
 UNAME_S := $(shell uname -s)
 UNAME_P := $(shell uname -p)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -54,6 +54,7 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"tsuru_service":                resourceTsuruService(),
 			"tsuru_service_instance_bind":  resourceTsuruServiceInstanceBind(),
 			"tsuru_service_instance_grant": resourceTsuruServiceInstanceGrant(),
 			"tsuru_service_instance":       resourceTsuruServiceInstance(),

--- a/internal/provider/resource_tsuru_service.go
+++ b/internal/provider/resource_tsuru_service.go
@@ -6,6 +6,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/antihax/optional"
@@ -105,20 +106,22 @@ func resourceTsuruServiceRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	name := d.Id()
 
-	services, _, err := provider.TsuruClient.ServiceApi.ServicesList(ctx)
+	_, resp, err := provider.TsuruClient.ServiceApi.ServiceInfo(ctx, name)
 	if err != nil {
-		return diag.Errorf("Could not list tsuru services, err: %s", err.Error())
+		return diag.Errorf("Could not get tsuru service %q, err: %s", name, err.Error())
 	}
 
-	for _, svc := range services {
-		if svc.Service == name {
-			d.Set("name", name)
-			return nil
-		}
+	if resp.StatusCode == http.StatusNotFound {
+		d.SetId("")
+		return nil
 	}
 
-	d.SetId("")
-	return nil
+	if resp.StatusCode == http.StatusOK {
+		d.SetId(name)
+		return nil
+	}
+
+	return diag.Errorf("Unexpected response code %d when getting tsuru service %q", resp.StatusCode, name)
 }
 
 func resourceTsuruServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_tsuru_service.go
+++ b/internal/provider/resource_tsuru_service.go
@@ -1,0 +1,168 @@
+// Copyright 2021 tsuru authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package provider
+
+import (
+	"context"
+	"time"
+
+	"github.com/antihax/optional"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/tsuru/go-tsuruclient/pkg/tsuru"
+)
+
+func resourceTsuruService() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceTsuruServiceCreate,
+		ReadContext:   resourceTsuruServiceRead,
+		UpdateContext: resourceTsuruServiceUpdate,
+		DeleteContext: resourceTsuruServiceDelete,
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(60 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Service name",
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Username for service authentication",
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Password for service authentication",
+			},
+			"endpoint": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Service endpoint URL",
+			},
+			"multi_cluster": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether the service supports multi-cluster",
+			},
+			"team": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Team owner of this service",
+			},
+		},
+	}
+}
+
+func resourceTsuruServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	provider := meta.(*tsuruProvider)
+
+	name := d.Get("name").(string)
+
+	opts := &tsuru.ServiceCreateOpts{
+		Id:       optional.NewString(name),
+		Endpoint: optional.NewString(d.Get("endpoint").(string)),
+		Team:     optional.NewString(d.Get("team").(string)),
+	}
+
+	if v, ok := d.GetOk("username"); ok {
+		opts.Username = optional.NewString(v.(string))
+	}
+
+	if v, ok := d.GetOk("password"); ok {
+		opts.Password = optional.NewString(v.(string))
+	}
+
+	if d.Get("multi_cluster").(bool) {
+		opts.MultiCluster = optional.NewString("true")
+	}
+
+	_, err := provider.TsuruClient.ServiceApi.ServiceCreate(ctx, opts)
+	if err != nil {
+		return diag.Errorf("Could not create tsuru service %q, err: %s", name, err.Error())
+	}
+
+	d.SetId(name)
+
+	return resourceTsuruServiceRead(ctx, d, meta)
+}
+
+func resourceTsuruServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	provider := meta.(*tsuruProvider)
+
+	name := d.Id()
+
+	services, _, err := provider.TsuruClient.ServiceApi.ServicesList(ctx)
+	if err != nil {
+		return diag.Errorf("Could not list tsuru services, err: %s", err.Error())
+	}
+
+	for _, svc := range services {
+		if svc.Service == name {
+			d.Set("name", name)
+			return nil
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceTsuruServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	provider := meta.(*tsuruProvider)
+
+	name := d.Id()
+
+	opts := &tsuru.ServiceUpdateOpts{
+		Id:       optional.NewString(name),
+		Endpoint: optional.NewString(d.Get("endpoint").(string)),
+		Team:     optional.NewString(d.Get("team").(string)),
+	}
+
+	if v, ok := d.GetOk("username"); ok {
+		opts.Username = optional.NewString(v.(string))
+	}
+
+	if v, ok := d.GetOk("password"); ok {
+		opts.Password = optional.NewString(v.(string))
+	}
+
+	if d.Get("multi_cluster").(bool) {
+		opts.MultiCluster = optional.NewString("true")
+	} else {
+		opts.MultiCluster = optional.NewString("false")
+	}
+
+	_, err := provider.TsuruClient.ServiceApi.ServiceUpdate(ctx, name, opts)
+	if err != nil {
+		return diag.Errorf("Could not update tsuru service %q, err: %s", name, err.Error())
+	}
+
+	return resourceTsuruServiceRead(ctx, d, meta)
+}
+
+func resourceTsuruServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	provider := meta.(*tsuruProvider)
+
+	name := d.Id()
+
+	_, err := provider.TsuruClient.ServiceApi.ServiceDelete(ctx, name)
+	if err != nil {
+		return diag.Errorf("Could not delete tsuru service %q, err: %s", name, err.Error())
+	}
+
+	return nil
+}

--- a/internal/provider/resource_tsuru_service_test.go
+++ b/internal/provider/resource_tsuru_service_test.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	echo "github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccTsuruService_basic(t *testing.T) {
+	fakeServer := echo.New()
+
+	fakeServer.POST("/1.0/services", func(c echo.Context) error {
+		id := c.FormValue("id")
+		endpoint := c.FormValue("endpoint")
+		team := c.FormValue("team")
+
+		assert.Equal(t, "my-service", id)
+		assert.Equal(t, "http://my-service.example.com", endpoint)
+		assert.Equal(t, "my-team", team)
+
+		return c.NoContent(http.StatusCreated)
+	})
+
+	fakeServer.GET("/1.0/services", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, []map[string]interface{}{
+			{
+				"service":   "my-service",
+				"instances": []string{},
+			},
+		})
+	})
+
+	fakeServer.PUT("/1.0/services/:name", func(c echo.Context) error {
+		name := c.Param("name")
+		assert.Equal(t, "my-service", name)
+		return c.NoContent(http.StatusOK)
+	})
+
+	fakeServer.DELETE("/1.0/services/:name", func(c echo.Context) error {
+		name := c.Param("name")
+		assert.Equal(t, "my-service", name)
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	fakeServer.HTTPErrorHandler = func(err error, c echo.Context) {
+		t.Errorf("methods=%s, path=%s, err=%s", c.Request().Method, c.Path(), err.Error())
+	}
+	server := httptest.NewServer(fakeServer)
+	os.Setenv("TSURU_TARGET", server.URL)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTsuruServiceConfig_basic(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("tsuru_service.my_service", "name", "my-service"),
+					resource.TestCheckResourceAttr("tsuru_service.my_service", "endpoint", "http://my-service.example.com"),
+					resource.TestCheckResourceAttr("tsuru_service.my_service", "team", "my-team"),
+					resource.TestCheckResourceAttr("tsuru_service.my_service", "multi_cluster", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTsuruServiceConfig_basic() string {
+	return `
+resource "tsuru_service" "my_service" {
+	name     = "my-service"
+	endpoint = "http://my-service.example.com"
+	team     = "my-team"
+}
+`
+}

--- a/internal/provider/resource_tsuru_service_test.go
+++ b/internal/provider/resource_tsuru_service_test.go
@@ -26,7 +26,9 @@ func TestAccTsuruService_basic(t *testing.T) {
 		return c.NoContent(http.StatusCreated)
 	})
 
-	fakeServer.GET("/1.0/services", func(c echo.Context) error {
+	fakeServer.GET("/1.0/services/:name", func(c echo.Context) error {
+		name := c.Param("name")
+		assert.Equal(t, "my-service", name)
 		return c.JSON(http.StatusOK, []map[string]interface{}{
 			{
 				"service":   "my-service",


### PR DESCRIPTION
Allow users to create, update, and delete tsuru services via Terraform, supporting endpoint, team ownership, credentials, and multi-cluster configuration.